### PR TITLE
Fix issue where commands on macOS is truncated

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,6 @@ import readline from "readline";
 import { FirebaseCommands } from "./firebase-cmd";
 import { CommandLineInterface } from "./cli";
 import { ChildProcess } from "child_process";
-
 interface CommandConfig {
   label: string;
   usage: string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
         ],
         "declaration": true,
         "sourceMap": true,
-        "outDir": "dist"
+        "outDir": "dist",
     },
     "lib": [
         "es2015"


### PR DESCRIPTION
Fixes #4 

Changes `spawn`-> `exec`

Reasoning behind this is that on macOS, command with long output will be truncated when using `spawn`. `exec` outputs separate `data`, so add those values to a buffer and process then on `end` event

Keep the `spawn` for running `firebase <command> --help` since outputs of these command are usually short. 