### PR TITLE
Add --version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onfire-cli",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A CLI that extends the Firebase CLI",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import readline from "readline";
 import { FirebaseCommands } from "./firebase-cmd";
 import { CommandLineInterface } from "./cli";
 import { ChildProcess } from "child_process";
+import packageJSON from "./packageJSON";
 interface CommandConfig {
   label: string;
   usage: string;
@@ -486,5 +487,16 @@ class OnFireCLI extends CommandLineInterface {
   }
 }
 
-const cli = new OnFireCLI({ prefix: "> " });
-cli.init();
+function initializeApp() {
+  const cli = new OnFireCLI({ prefix: "> " });
+  if (process.argv.length <= 2) {
+    cli.init();
+  } else if (process.argv.includes("--version")) {
+    console.log(`OnFire: v${packageJSON.version}`);
+  } else {
+    console.log(`OnFire: Unknown args ${process.argv.slice(2).join(", ")}`);
+    console.log(`Type 'onfire' to initialize the OnFire CLI`);
+  }
+}
+
+initializeApp();

--- a/src/packageJSON.js
+++ b/src/packageJSON.js
@@ -1,0 +1,2 @@
+var pjson = require('../package.json');
+module.exports = pjson

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
             "es6",
             "dom"
         ],
+        "allowJs": true,
         "declaration": true,
         "sourceMap": true,
         "outDir": "dist",


### PR DESCRIPTION
Fixes #1 

Add `--version` flag

`onfire --version` will now show the installed version of OnFire CLI