### PR TITLE
Multiple fix and clean up

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -82,13 +82,15 @@ export class CommandLineInterface {
       [key: string]: string;
     };
     options: Array<string>;
+    input: Array<string>;
   } {
     const args = command.split(" ");
     let _base = args[0];
     let _arguments = {};
     let _options = [];
+    let _input = [];
     if (args === null) return null;
-    for (let i = 0; i < args.length; i++) {
+    for (let i = 1; i < args.length; i++) {
       if (args[i].includes("=")) {
         const splitArg = args[i].split("=");
         if (_arguments === null) {
@@ -118,6 +120,9 @@ export class CommandLineInterface {
             _arguments[args[i]] = args[i + 1];
           }
         }
+        i++; // TODO: This might introduce bugs, remove if it does.
+      } else {
+        _input.push(args[i]);
       }
     }
 
@@ -125,6 +130,7 @@ export class CommandLineInterface {
       base: _base,
       args: _arguments,
       options: _options,
+      input: _input,
     };
   }
 

--- a/src/firebase-cmd.ts
+++ b/src/firebase-cmd.ts
@@ -52,7 +52,19 @@ export class FirebaseCommands {
       npmSpawnPath.stdout.on("end", () => {
         clearTimeout(rejectTimout);
         const rootPath = bufferString.toString().trim();
-        this.client = require(`${rootPath}/firebase-tools`);
+        try {
+          this.client = require(`${rootPath}/firebase-tools`);
+        } catch (error) {
+          if (error.code === "MODULE_NOT_FOUND") {
+            reject(
+              new Error(
+                `Firebase Tools module not found. Install using 'npm install -g firebase-tools'`
+              )
+            );
+          } else {
+            new Error(`Unexpected error was raised. ${error.message}`);
+          }
+        }
         resolve(this.client);
       });
     });
@@ -67,7 +79,10 @@ export class FirebaseCommands {
       (comMap: any, com: any) => {
         comMap[com._name] = {
           command: com._name,
-          description: com._description,
+          description: (com._description || "No description").replace(
+            /\n.*/g,
+            ""
+          ),
           usage: `firebase ${com._name} [options] ${com._args
             .map((arg: FirebaseCommandArgs) => {
               let usage = arg.name;


### PR DESCRIPTION
Remove unused `loadCommandHelp()` method in "src/index.ts"
- This will no longer be needed as command options will always be loaded on init
Added logic to get additional inputs on command input in "src/cli.ts"
Add catch condition if there is no Firebase module and fix init overflow issue "src/firebase-cmd.ts"