### PR TITLE
Implements feature for argument tab autocompletion

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "build": "tsc",
     "build:watch": "tsc --watch",
     "test": "jest --coverage --verbose",
-    "test:onfire-cli": "jest -- onfire-cli.test.ts"
+    "test:onfire-cli": "jest --coverage -- onfire-cli.test.ts",
+    "test:cli-cache": "jest --coverage -- cli-cache.test.ts"
   },
   "bin": {
     "onfire": "./dist/index.js"

--- a/src/cli-cache.ts
+++ b/src/cli-cache.ts
@@ -1,19 +1,20 @@
 import path from "path";
 import { mkdir, readFile, stat, writeFile } from "fs/promises";
 
-const APP_NAME = "onfire-cli";
+export const APP_NAME = "onfire-cli";
+export const MAX_CACHE_COUNT = 10;
 
 export class CliCache {
   static async getAppDir(): Promise<string> {
-    var plat = process.platform;
+    let plat = process.platform;
 
-    var homeDir = process.env[plat == "win32" ? "USERPROFILE" : "HOME"];
-    var appDir = null;
+    let homeDir = process.env[plat == "win32" ? "USERPROFILE" : "HOME"];
+    let appDir = null;
 
     if (plat == "win32") {
-      appDir = path.join(homeDir, "AppData", APP_NAME);
+      appDir = path.join(homeDir, "AppData", `${APP_NAME}`);
     } else {
-      appDir = path.join(homeDir, "." + APP_NAME);
+      appDir = path.join(homeDir, "." + `${APP_NAME}`);
     }
 
     try {
@@ -31,7 +32,8 @@ export class CliCache {
 
   static async readFromFile(): Promise<Object> {
     const dirPath = await CliCache.getAppDir();
-    const filePath = path.join(dirPath, "cache.json");
+    const additionalPath = process.env.TEST_CACHE_PATH || "";
+    const filePath = path.join(dirPath, `cache${additionalPath}.json`);
     let _obj = {};
     try {
       await stat(filePath);
@@ -53,7 +55,8 @@ export class CliCache {
 
   static async writeToFile(obj: Object): Promise<void> {
     const dirPath = await CliCache.getAppDir();
-    const filePath = path.join(dirPath, "cache.json");
+    const additionalPath = process.env.TEST_CACHE_PATH || "";
+    const filePath = path.join(dirPath, `cache${additionalPath}.json`);
 
     try {
       await writeFile(filePath, JSON.stringify(obj, null, 4));

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -90,13 +90,16 @@ export class CommandLineInterface {
     args: {
       [key: string]: string;
     };
+    flags: Array<string>;
     options: Array<string>;
     input: Array<string>;
   } {
-    const args = command.split(" ");
+    const args = command.match(/(".*?"|[^"\s]+)+(?=\s*|\s*$)/g) || [""];
+    // const args = command.split(" ");
     let _base = args[0];
     let _arguments = {};
     let _options = [];
+    let _flags = [];
     let _input = [];
     if (args === null) return null;
     for (let i = 1; i < args.length; i++) {
@@ -109,6 +112,7 @@ export class CommandLineInterface {
         } else {
           _arguments[splitArg[0]] = splitArg[1];
         }
+        _flags.push(splitArg[0]);
       } else if (args[i].startsWith("-")) {
         if (
           args.length - 1 === i ||
@@ -131,6 +135,7 @@ export class CommandLineInterface {
           }
         }
 
+        _flags.push(args[i]);
         if (!options.includes(args[i]) && !args[i + 1]?.startsWith("-")) {
           i++; // TODO: This might introduce bugs, remove if it does.
         }
@@ -145,6 +150,7 @@ export class CommandLineInterface {
       base: _base,
       args: _arguments,
       options: _options,
+      flags: _flags,
       input: _input,
     };
   }
@@ -171,5 +177,9 @@ export class CommandLineInterface {
 
   protected textBold(str: string) {
     return `\x1b[1m${str}\x1b[0m`;
+  }
+
+  protected capitalizeFirstLetter(str: string) {
+    return str[0].toUpperCase() + str.slice(1);
   }
 }

--- a/tests/cli-cache.test.ts
+++ b/tests/cli-cache.test.ts
@@ -1,0 +1,73 @@
+import path from "path";
+import { APP_NAME, CliCache } from "../src/cli-cache";
+import { unlink } from "fs/promises";
+
+describe("Test caching", () => {
+  process.env.TEST_CACHE_PATH = "-test";
+  let plat = process.platform;
+  let homeDir = process.env[plat == "win32" ? "USERPROFILE" : "HOME"];
+  let testAppDir: string = "";
+
+  beforeAll(() => {
+    if (homeDir == undefined) {
+      throw Error("homeDir is undefined");
+    }
+    if (plat == "win32") {
+      testAppDir = path.join(homeDir, "AppData", `${APP_NAME}`);
+    } else {
+      testAppDir = path.join(homeDir, "." + `${APP_NAME}`);
+    }
+  });
+
+  it("Should get the app cache directory", async () => {
+    const appDir = await CliCache.getAppDir();
+
+    expect(appDir).toBe(testAppDir);
+  });
+
+  it("Should read the cache empty json file", async () => {
+    const contents = await CliCache.readFromFile();
+
+    expect(contents).toEqual({});
+  });
+
+  afterAll(async () => {
+    await CliCache.writeToFile({});
+  });
+});
+
+describe("Test reading cache", () => {
+  process.env.TEST_CACHE_PATH = "-test";
+  let plat = process.platform;
+  let homeDir = process.env[plat == "win32" ? "USERPROFILE" : "HOME"];
+  let testAppDir: string = "";
+  const obj = {
+    pastCommands: [
+      "emulators:start --project demo-project",
+      "functions:shell --port 5000 --project demo-project",
+      "appdistribution:distribute --project demo-proj --app=1:1234567890:ios:321abc456def7890",
+    ],
+  };
+
+  beforeAll(async () => {
+    if (homeDir == undefined) {
+      throw Error("homeDir is undefined");
+    }
+    if (plat == "win32") {
+      testAppDir = path.join(homeDir, "AppData", `${APP_NAME}-test`);
+    } else {
+      testAppDir = path.join(homeDir, "." + `${APP_NAME}-test`);
+    }
+    await CliCache.writeToFile(JSON.stringify(obj));
+  });
+
+  it("Should read the cache from json file", async () => {
+    const contents = await CliCache.readFromFile();
+
+    expect(JSON.parse(contents.toString())).toEqual(obj);
+  });
+
+  afterAll(async () => {
+    await CliCache.writeToFile({});
+  });
+});

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -7,6 +7,7 @@ class MockCommandLineInterface extends CommandLineInterface {
   ): {
     base: string;
     args: { [key: string]: string };
+    flags: string[];
     options: string[];
     input: string[];
   } {
@@ -16,14 +17,21 @@ class MockCommandLineInterface extends CommandLineInterface {
   _textRed(str: string): string {
     return this.textRed(str);
   }
+
   _textGreen(str: string): string {
     return this.textGreen(str);
   }
+
   _textYellow(str: string): string {
     return this.textYellow(str);
   }
+
   _textBold(str: string): string {
     return this.textBold(str);
+  }
+
+  _capitalizeFirstLetter(str: string): string {
+    return this.capitalizeFirstLetter(str);
   }
 }
 
@@ -49,6 +57,11 @@ describe("Text formatting", () => {
   it("Should make the text bold", () => {
     const wrappedText = cli._textBold(text);
     expect(wrappedText).toBe(`\x1b[1m${text}\x1b[0m`);
+  });
+
+  it("Should capitalize the first letter of 'this is a sentence'", () => {
+    const wrappedText = cli._capitalizeFirstLetter("this is a sentence");
+    expect(wrappedText).toBe(`This is a sentence`);
   });
 });
 
@@ -86,5 +99,26 @@ describe("Deconstuct commands", () => {
     expect(options.includes("--debug")).toBe(true);
     expect(input[0]).toBe("bin_file");
     expect(args["--app"]).toBe("app_id");
+  });
+
+  it(`Should deconstuct command with '=' sign: 'appdistribution:distribute --debug --app=app_id bin_file --release-notes "This is the release notes" --project=demo-proj'`, () => {
+    const command = `appdistribution:distribute --debug --app=app_id bin_file --release-notes "This is the release notes" --project=demo-proj"`;
+    const { base, args, options, input } = cli._getCommandParams(command, [
+      "--debug",
+    ]);
+
+    expect(base).toBe("appdistribution:distribute");
+    expect(options.includes("--debug")).toBe(true);
+    expect(input[0]).toBe("bin_file");
+    expect(args["--app"]).toBe("app_id");
+    expect(args["--project"]).toBe("demo-proj");
+    expect(args["--release-notes"]).toBe(`"This is the release notes"`);
+  });
+
+  it("Should list all flags passed for 'appdistribution:distribute --debug --app app_id bin_file --project demo-proj'", () => {
+    const command = `appdistribution:distribute --debug --app app_id bin_file --project demo-proj`;
+    const { flags } = cli._getCommandParams(command, ["--debug"]);
+
+    expect(flags).toEqual(["--debug", "--app", "--project"]);
   });
 });


### PR DESCRIPTION
Major change
- finalized caching
- added argument caching
- finalized past command caching
- implemented additional tests
- fixed issue where params that have space will fail
   - For example `--release-notes "This is a release note"` would only register "This" as the release note