### PR TITLE
Catch timeout

### DIFF
--- a/src/firebase-cmd.ts
+++ b/src/firebase-cmd.ts
@@ -1,7 +1,7 @@
 import { ChildProcess, SpawnOptions, exec, fork } from "child_process";
 import spawn from "cross-spawn";
 
-const COMMAND_TIMEOUT = 1000;
+const COMMAND_TIMEOUT = 10000;
 
 export const DEFAULT_FEATURES = [
   "database",

--- a/src/firebase-cmd.ts
+++ b/src/firebase-cmd.ts
@@ -1,7 +1,7 @@
 import { ChildProcess, SpawnOptions, exec, fork } from "child_process";
 import spawn from "cross-spawn";
 
-const COMMAND_TIMEOUT = 10000;
+const COMMAND_TIMEOUT = 1000;
 
 export const DEFAULT_FEATURES = [
   "database",

--- a/src/onfire-cli.ts
+++ b/src/onfire-cli.ts
@@ -830,11 +830,16 @@ export class OnFireCLI extends CommandLineInterface {
       this.firebaseCommands = await this.firebaseCli.getCommandConfig();
     } else {
       this.firebaseCommands = this.savedConfig["firebaseCommands"];
-      this.firebaseCli.getCommandConfig().then((firebaseCommands) => {
-        this.firebaseCommands = firebaseCommands;
-        this.savedConfig["firebaseCommands"] = this.firebaseCommands;
-        this.attachCustomCommands();
-      });
+      this.firebaseCli
+        .getCommandConfig()
+        .then((firebaseCommands) => {
+          this.firebaseCommands = firebaseCommands;
+          this.savedConfig["firebaseCommands"] = this.firebaseCommands;
+          this.attachCustomCommands();
+        })
+        .catch((_) => {
+          // No action needed since we can use the cached firebaseCommands
+        });
     }
     this.attachCustomCommands();
     this.savedConfig["firebaseCommands"] = this.firebaseCommands;


### PR DESCRIPTION
Catches  timeout error when firebaseCommands cache exists

We try to load the firebaseCommands by loading the Firebase Tools module. In certain scenarios where it takes too long to load the Firebase Tools module, we should not throw an error if we have a copy of firebaseCommands cached.